### PR TITLE
Fixed bug with negative shoping card counter

### DIFF
--- a/index.html
+++ b/index.html
@@ -205,11 +205,11 @@
           removeOne: function( product ) {
             product.quantity--;
             if ( product.quantity <= 0 ) {
-                this.shopping_cart.$remove( product );
+                this.shopping_cart.pop( product );
             }
           },
           removeFromCart: function( product ) {
-            this.shopping_cart.$remove( product );
+            this.shopping_cart.pop( product );
           }
         },
         computed: {


### PR DESCRIPTION
Shoping card items could not be deleted with '$remove' and u could get negative numbers of items in shoping card. Changed '$remove' to 'pop' to fix this behavior. Project wasnt updated for 3 years already but i thought i will give it a try, so people learning vue now didnt made same mistake.